### PR TITLE
RPM spec updated to exclude autodetected osgi requirements

### DIFF
--- a/eucalyptus-java-deps.spec
+++ b/eucalyptus-java-deps.spec
@@ -13,6 +13,9 @@ BuildArch:      noarch
 # usual systemwide locations
 %global __provides_exclude_from ^%{_datadir}/eucalyptus/.*.jar$
 
+# Disable automatic OSGI Requires because we provide all dependencies
+%global __requires_exclude osgi(.*)
+
 Provides:       eucalyptus-java-deps-devel = %{name}-%{release}
 
 


### PR DESCRIPTION
This will remove any osgi(*) dependencies from the rpm:

```
# rpm -qp --requires eucalyptus-java-deps-4.4-0.20171215git4378667.el7.noarch.rpm
osgi(org.apache.xerces)
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1
```

i.e. with the fix in place the output of the above command will not include "osgi(org.apache.xerces)"

Example showing dependencies from 4.4.2 release:

```
# rpm -qp --requires eucalyptus-java-deps-4.4-0.254.5.el7.noarch.rpm
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1
```